### PR TITLE
Android - return available bytes instead of free bytes

### DIFF
--- a/src/android/DiskSpacePlugin.java
+++ b/src/android/DiskSpacePlugin.java
@@ -62,7 +62,7 @@ public class DiskSpacePlugin extends CordovaPlugin {
             JSONObject objRes = new JSONObject();
             objRes.put("app", getFolderSize(appDir));
             objRes.put("total", statFs.getTotalBytes());
-            objRes.put("free", statFs.getFreeBytes());
+            objRes.put("free", statFs.getAvailableBytes());
             callbackContext.success(objRes);
         }
 


### PR DESCRIPTION
[StatFs#getFreeBytes()](https://developer.android.com/reference/android/os/StatFs#getFreeBytes()) is used to return **free** value on Android
described as:
> The number of bytes that are free on the file system, including reserved blocks (that are not available to normal applications). Most applications will want to use getAvailableBytes() instead.

free space of *reserved blocks* / *not available to normal applications* does not seem to be relevant for _us_ either

⇒ So, I suggest to use [StatFs#getAvailableBytes()](https://developer.android.com/reference/android/os/StatFs#getAvailableBytes()) instead

(same "freeSpace" is implemented in [cordova-diagnostic-plugin](https://github.com/dpa99c/cordova-diagnostic-plugin/blob/master/src/android/Diagnostic_External_Storage.java#L160): Diagnostic_External_Storage.java#[L178](https://github.com/dpa99c/cordova-diagnostic-plugin/blob/master/src/android/Diagnostic_External_Storage.java#L178))