### PR TITLE
Use <header-file> to declare ios .h file

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -49,7 +49,7 @@
                 <param name="onload" value="true"/>
             </feature>
         </config-file>
-	<source-file src="src/ios/DiskSpacePlugin.h"/>
+        <header-file src="src/ios/DiskSpacePlugin.h"/>
         <source-file src="src/ios/DiskSpacePlugin.m"/>
     </platform>
 </plugin>


### PR DESCRIPTION
Prefer [\<header-file\>](https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html#header-file) element to declare `DiskSpacePlugin.h` inside _plugin.xml_