### PR TITLE
Android!: add appFilesPath option and default location to internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,21 @@ Add your platforms targeted:
 
 Where options is a javascript object:
 
-	location: 1 // To get information about external storage (For android only)
-	location: 2 // To get information about internal storage (For android only)
+	location: 1
+        // To get information about external storage (For Android only)
+	location: 2
+        // or missing, or any other value (default)
+        // To get information about internal storage (For Android only)
+
+    appFilesPath: cordova.file.dataDirectory
+    appFilesPath: cordova.file.externalDataDirectory
+        // examples using cordova-plugin-file constants here, but can be any path to other app's `files`
+        // To get information about any storage by path, like internal, external, or removable externals / SD cards (For Android only)
 
 The result object is like that:
 
 	{
 		"app": 29887, // Space occupied by the current application
-		"total": 98717873000, // Total space of the device
-		"free": 76556280  // Free space of the device
+		"total": 98717873000, // Total space of the storage
+		"free": 76556280  // Free space of the storage
 	}

--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ Add your platforms targeted:
 Where options is a javascript object:
 
 	location: 1
-        // To get information about external storage (For Android only)
+		// To get information about external storage (For Android only)
 	location: 2
-        // or missing, or any other value (default)
-        // To get information about internal storage (For Android only)
+		// or missing, or any other value (default)
+		// To get information about internal storage (For Android only)
 
-    appFilesPath: cordova.file.dataDirectory
-    appFilesPath: cordova.file.externalDataDirectory
-        // examples using cordova-plugin-file constants here, but can be any path to other app's `files`
-        // To get information about any storage by path, like internal, external, or removable externals / SD cards (For Android only)
+	appFilesPath: cordova.file.dataDirectory
+	appFilesPath: cordova.file.externalDataDirectory
+		// examples using cordova-plugin-file constants here, but can be any path to other app's `files`
+		// To get information about any storage by path, like internal, external, or removable externals / SD cards (For Android only)
 
 The result object is like that:
 

--- a/src/android/DiskSpacePlugin.java
+++ b/src/android/DiskSpacePlugin.java
@@ -38,26 +38,26 @@ public class DiskSpacePlugin extends CordovaPlugin {
     public boolean execute(final String action, JSONArray args,
                            CallbackContext callbackContext) throws JSONException {
 
-        int location = 1;
-        try {
-            location = args.getJSONObject(0).getInt("location");
-        } catch (JSONException e) {
-
-        }
-
         if ("info".equals(action)) {
-            StatFs statFs = null;
-
-            String packageName = this.cordova.getActivity().getPackageName();
-            File appDir = null;
-
-            if (location == 1) {
-                statFs = new StatFs(Environment.getExternalStorageDirectory().getAbsolutePath());
-                appDir = new File(Environment.getExternalStorageDirectory().getAbsolutePath() + File.separator + "Android" + File.separator + "data" + File.separator + packageName + File.separator + "files");
-            } else {
-                statFs = new StatFs(Environment.getDataDirectory().getAbsolutePath());
-                appDir = new File(Environment.getDataDirectory().getAbsolutePath() + File.separator + "data" + File.separator + packageName + File.separator + "files");
+            File appDir = cordova.getContext().getFilesDir();
+            File fsDir = Environment.getDataDirectory();
+            JSONObject options = args.optJSONObject(0);
+            if (options != null) {
+                String appFilesPath = options.optString("appFilesPath").replace("file://", "").replaceFirst("/$", "");
+                if (!appFilesPath.isEmpty()) {
+                    if (!appFilesPath.equals(appDir.getAbsolutePath())) {
+                        appDir = new File(appFilesPath);
+                        fsDir = appDir.getParentFile().getParentFile().getParentFile().getParentFile();
+                    }
+                } else {
+                    int location = options.optInt("location");
+                    if (location == 1) {
+                        appDir = cordova.getContext().getExternalFilesDir(null);
+                        fsDir = appDir.getParentFile().getParentFile().getParentFile().getParentFile();
+                    }
+                }
             }
+            StatFs statFs = new StatFs(fsDir.getAbsolutePath());
 
             JSONObject objRes = new JSONObject();
             objRes.put("app", getFolderSize(appDir));


### PR DESCRIPTION
To be able to target a specific storage given the path to the corresponding app's `files` dir on it.

i.e. **internal**, **external**, and 🆕 **removable externals like SD cards**💾

&
⚠️ Changed the default storage info returned on Android when no option is set: **it will now be the internal storage instead of the external one!**